### PR TITLE
Fix: generateText is called twice and tailwind colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-.env
+*.env

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -18,18 +18,23 @@ export function Button({ children, styleType='primary', size='default', ...rest 
         'quarter': 'w-1/4',
         'default': ''
     }
+    const getCustomClass = () => {
+        if(styleType === 'success'){
+            return "bg-success hover:bg-success-dark"
+        }
 
-    const customClass = `
-        bg-${styleType}
-        hover:bg-${styleType}-dark
-        text-${styleType}-contrast
-        ${buttonSize[size]}
-    `
+        return `
+            bg-${styleType}
+            hover:bg-${styleType}-dark
+        `
+    }
 
     return (
         <div className={`p-2 ${buttonSize[size]}`}>
             <button
-            className={`${customClass} font-bold py-2 px-4 rounded`} {...rest}>
+                className={`${getCustomClass()} text-white ${buttonSize[size]} font-bold py-2 px-4 rounded`}
+                {...rest}
+            >
                 {children}
             </button>
         </div>

--- a/src/models/booking.ts
+++ b/src/models/booking.ts
@@ -23,7 +23,6 @@ export class Booking extends Event {
         const color = approvalColor[approval]
         const title = `${BOOKING_TITLE} ${username} - ${approvalText[approval]}`
         super(start, duration, username, color, title, id)
-        this.generateTexts()
     }
 
     generateTexts(){

--- a/src/models/checkin.ts
+++ b/src/models/checkin.ts
@@ -22,7 +22,6 @@ export class Checkin extends Event {
     ){
         const title = `${username} - ${local}`
         super(start, duration, username, color, title, id)
-        this.generateTexts()
     }
 
     generateTexts(){


### PR DESCRIPTION
The `generateText` was called 2 times, in the mother class and the class where the object is being instanced. With this problem, the text started to duplicate itself.

Since the title is no longer being set up on this function, we can let it be called only in the mother class.

Also fix the tailwind colors on build.